### PR TITLE
Fix `$li` counting of unequipped Perfected armor pieces, and count Refined armor pieces

### DIFF
--- a/cogs/guildwars2.py
+++ b/cogs/guildwars2.py
@@ -252,54 +252,57 @@ class GuildWars2:
         id_legendary_insight = 77302
         id_gift_of_prowess = 78989
         id_envoy_insignia = 80516
+        ids_refined_envoy_armor = {
+            # Helm, Shoulders, Coat,  Gloves, Leggings, Boots
+            80387,  80236,     80648, 80673,  80427,    80127, # Heavy
+            80634,  80366,     80607, 80658,  80675,    80177, # Medium
+            80441,  80264,     80120, 80460,  80275,    80583  # Light
+        }
         ids_perfected_envoy_armor = {
-            # Helm, Shoulders, Coat, Gloves, Leggings, Boots
-            80384, 80435, 80254, 80205, 80277, 80557, # heavy
-            80296, 80145, 80578, 80161, 80252, 80281, # medium
-            80248, 80131, 80190, 80111, 80356, 80399  # light
+            # Helm, Shoulders, Coat,  Gloves, Leggings, Boots
+            80384,  80435,     80254, 80205,  80277,    80557, # Heavy
+            80296,  80145,     80578, 80161,  80252,    80281, # Medium
+            80248,  80131,     80190, 80111,  80356,    80399  # Light
         }
 
-        # Filter empty slots out of the inventories to scan
+        # Filter empty slots and uninteresting items out of the inventories.
+        #
         # All inventories are converted to lists as they are used multiple
         # times. If they stay as generators, the first scan on each will exhaust
         # them, resulting in empty results for later scans (this was really hard
         # to track down, since the scans are also generators, so the order of
         # access to an inventory is not immediately obvious in the code).
-        # Since these lists may be large, also discard all completely
-        # uninteresting items right now.
-        __pre_filter = ids_perfected_envoy_armor.union({
-            id_legendary_insight, id_gift_of_prowess, id_envoy_insignia})
-        pre_filter = lambda a, b=__pre_filter: a["id"] in b
-        inv_bank = list(filter(pre_filter, filter(None, bank)))
+        __pre_filter = ids_perfected_envoy_armor.union(
+            {id_legendary_insight, id_gift_of_prowess, id_envoy_insignia},
+            ids_refined_envoy_armor)
+        # If an item slot is empty, or the item is not interesting, filter it out.
+        pre_filter = lambda a, b=__pre_filter: a is not None and a["id"] in b
+        inv_bank = list(filter(pre_filter, bank))
         del bank # We don't need these anymore, free them.
 
-        inv_shared = list(filter(pre_filter, filter(None, shared)))
+        inv_shared = list(filter(pre_filter, shared))
         del shared
 
         # Bags and equipment are a little more complicated
         # Bags have multiple inventories for each character, so:
-        # Step 6: Discard uninteresting
+        # Step 5: Discard the empty and uninteresting
         inv_bags = list(filter(pre_filter,
-            # Step 5: filter out empty slots
-            filter(None,
-                # Step 4: flatten!
+            # Step 4: Flatten!
+            chain.from_iterable(
+                # Step 3: Flatten.
                 chain.from_iterable(
-                    # Step 3: flatten.
-                    chain.from_iterable(
-                        # Step 2: get inventories from each existing bag
-                        (map(itemgetter("inventory"), filter(None, bags)) for bags in
-                            # Step 1: get all bags
-                            map(itemgetter("bags"), characters)))))))
+                    # Step 2: Get inventories from each existing bag
+                    (map(itemgetter("inventory"), filter(None, bags)) for bags in
+                        # Step 1: Get all bags
+                        map(itemgetter("bags"), characters))))))
         # Now we have a simple list of items in all bags on all characters.
 
-        # Step 4: Discard uninteresting
+        # Step 3: Discard empty and uninteresting
         equipped = list(filter(pre_filter,
-            # Step 3: flatten
+            # Step 2: Flatten
             chain.from_iterable(
-                # Step 2: Filter out empty slots
-                (filter(None, equipment) for equipment in
-                    # Step 1: get all character equipment
-                    map(itemgetter("equipment"), characters)))))
+                # Step 1: get all character equipment
+                map(itemgetter("equipment"), characters))))
         del characters
         # Like the bags, we now have a simple list of character gear
 
@@ -325,14 +328,21 @@ class GuildWars2:
 
         # This one is slightly different: since we are matching against a set
         # of ids, we use `in` instead of a simple comparison.
-        armor_scan = lambda a, b=ids_perfected_envoy_armor: a["id"] in b
-        armor_bank = map(itemgetter("count"), filter(armor_scan, inv_bank))
-        armor_shared = map(itemgetter("count"), filter(armor_scan, inv_shared))
-        armor_bags = map(itemgetter("count"), filter(armor_scan, inv_bags))
+        perfect_armor_scan = lambda a, b=ids_perfected_envoy_armor: a["id"] in b
+        perfect_armor_bank = map(itemgetter("count"), filter(perfect_armor_scan, inv_bank))
+        perfect_armor_shared = map(itemgetter("count"), filter(perfect_armor_scan, inv_shared))
+        perfect_armor_bags = map(itemgetter("count"), filter(perfect_armor_scan, inv_bags))
         # immediately converting this to a list because we'll need the length
         # later and that would exhaust the generator, resulting in surprises if
         # it's used more later.
-        armor_equipped = list(filter(armor_scan, equipped))
+        perfect_armor_equipped = list(filter(perfect_armor_scan, equipped))
+
+        # Repeat for Refined Armor
+        refined_armor_scan = lambda a, b=ids_refined_envoy_armor: a["id"] in b
+        refined_armor_bank = map(itemgetter("count"), filter(refined_armor_scan, inv_bank))
+        refined_armor_shared = map(itemgetter("count"), filter(refined_armor_scan, inv_shared))
+        refined_armor_bags = map(itemgetter("count"), filter(refined_armor_scan, inv_bags))
+        refined_armor_equipped = list(filter(refined_armor_scan, equipped))
 
         # Now that we have all the items we are interested in, it's time to
         # count them! Easy enough to just `sum` the `chain`.
@@ -342,15 +352,25 @@ class GuildWars2:
         # Armor is a little different. The ones in inventory have a count like
         # the other items, but the ones equipped don't, so we can just take the
         # length of the list there.
-        sum_armor = sum(chain(armor_bank, armor_shared, armor_bags)) + len(armor_equipped)
+        sum_refined_armor = sum(chain(refined_armor_bank, refined_armor_shared, refined_armor_bags)) + len(refined_armor_equipped)
+        sum_perfect_armor = sum(chain(perfect_armor_bank, perfect_armor_shared, perfect_armor_bags)) + len(perfect_armor_equipped)
 
         # LI is fine, but the others are composed of 25 or 50 LIs.
         li_prowess = sum_prowess * 25
         li_insignia = sum_insignia * 25
-        # First set is half off!
-        li_armor = li_armor = 6 * 25 + (sum_armor - 6) * 50 if sum_armor > 6 else sum_armor * 25
+        # Refined Envoy Armor. First set is free!
+        # But, keeping track of it is troublesome. What we do is add up to 6
+        # perfected armor pieces to this (the ones that used the free set), but
+        # not more (`min()`).
+        # Then, subtract 6 for the free set. If one full set of perfected armor
+        # has been crafted, then we have just the count of refined armor. This
+        # is exactly what we want, because the free set is now being counted by
+        # `li_perfect_armor`.
+        li_refined_armor = max(min(sum_perfect_armor, 6) + sum_refined_armor - 6, 0) * 25
+        # Perfected Envoy Armor. First set is half off!
+        li_perfect_armor = 6 * 25 + max(sum_perfect_armor - 6, 0) * 50
         # Stagger the calculation for detail later.
-        crafted_li = li_prowess + li_insignia + li_armor
+        crafted_li = li_prowess + li_insignia + li_perfect_armor + li_refined_armor
         total_li = sum_li + crafted_li
 
         # Construct an embed object for better formatting of our data
@@ -366,18 +386,26 @@ class GuildWars2:
         # Quick breakdown. No detail on WHERE all those LI are. That's for $search.
         embed.description = "{1} on hand, {2} used in crafting".format(total_li, sum_li, crafted_li)
         # Save space by skipping empty sections
-        if sum_armor > 0:
+        if sum_perfect_armor > 0:
             embed.add_field(
-                name="{0} Perfected Envoy Armor Pieces".format(sum_armor), inline=False,
-                value="Representing {0} Legendary Insights".format(li_armor))
+                name="{0} Perfected Envoy Armor Pieces".format(sum_perfect_armor),
+                value="Representing {0} Legendary Insights".format(li_perfect_armor),
+                inline=False)
+        if sum_refined_armor > 0:
+            embed.add_field(
+                name="{0} Refined Envoy Armor Pieces".format(sum_refined_armor),
+                value="Representing {0} Legendary Insights".format(li_refined_armor),
+                inline=False)
         if sum_prowess > 0:
             embed.add_field(
-                name="{0} Gifts of Prowess".format(sum_prowess), inline=False,
-                value="Representing {0} Legendary Insights".format(li_prowess))
+                name="{0} Gifts of Prowess".format(sum_prowess),
+                value="Representing {0} Legendary Insights".format(li_prowess),
+                inline=False)
         if sum_insignia > 0:
             embed.add_field(
-                name="{0} Envoy Insignia".format(sum_insignia), inline=False,
-                value="Representing {0} Legendary Insights".format(li_insignia))
+                name="{0} Envoy Insignia".format(sum_insignia),
+                value="Representing {0} Legendary Insights".format(li_insignia),
+                inline=False)
         # Identify the bot
         embed.set_footer(text=self.bot.user.name, icon_url=self.bot.user.avatar_url)
 

--- a/cogs/guildwars2.py
+++ b/cogs/guildwars2.py
@@ -326,9 +326,9 @@ class GuildWars2:
         # This one is slightly different: since we are matching against a set
         # of ids, we use `in` instead of a simple comparison.
         armor_scan = lambda a, b=ids_perfected_envoy_armor: a["id"] in b
-        armor_bank = filter(armor_scan, inv_bank)
-        armor_shared = filter(armor_scan, inv_shared)
-        armor_bags = filter(armor_scan, inv_bags)
+        armor_bank = map(itemgetter("count"), filter(armor_scan, inv_bank))
+        armor_shared = map(itemgetter("count"), filter(armor_scan, inv_shared))
+        armor_bags = map(itemgetter("count"), filter(armor_scan, inv_bags))
         # immediately converting this to a list because we'll need the length
         # later and that would exhaust the generator, resulting in surprises if
         # it's used more later.


### PR DESCRIPTION
This pull request contains a fix for crash while handling unequipped Perfected Envoy armor pieces, and adds Refined Envoy armor pieces to the tally, which had previously been omitted.

# Include Refined armor in `$li`'s tally
The first iteration of the more powerful `$li` command failed to
account for Refined Envoy Armor pieces. This has been rectified.

Up to 6 of the total Perfected Envoy Armor count are added to the
Refined count, which offsets the subtraction of the 6 free pieces,
resulting in the count of crafted Refined pieces.

# Fix an issue regarding unequipped armor pieces.
Armor in bank, bags, or shared slots were not having their `count`
extracted, resulting in the entire Item dictionary being sent to
`sum()`, which choked on it (can't add dictionaries together like
that).