### PR TITLE
Fully complete and (hopefully) bug free updated `$li` command.

### DIFF
--- a/cogs/guildwars2.py
+++ b/cogs/guildwars2.py
@@ -248,22 +248,12 @@ class GuildWars2:
             return
 
         # Items to look for
-        # TODO: Move out of code
-        id_legendary_insight = 77302
-        id_gift_of_prowess = 78989
-        id_envoy_insignia = 80516
-        ids_refined_envoy_armor = {
-            # Helm, Shoulders, Coat,  Gloves, Leggings, Boots
-            80387,  80236,     80648, 80673,  80427,    80127, # Heavy
-            80634,  80366,     80607, 80658,  80675,    80177, # Medium
-            80441,  80264,     80120, 80460,  80275,    80583  # Light
-        }
-        ids_perfected_envoy_armor = {
-            # Helm, Shoulders, Coat,  Gloves, Leggings, Boots
-            80384,  80435,     80254, 80205,  80277,    80557, # Heavy
-            80296,  80145,     80578, 80161,  80252,    80281, # Medium
-            80248,  80131,     80190, 80111,  80356,    80399  # Light
-        }
+        ids = self.gamedata.get("insights")
+        id_legendary_insight = ids.get("legendary_insight")
+        id_gift_of_prowess = ids.get("gift_of_prowess")
+        id_envoy_insignia = ids.get("envoy_insignia")
+        ids_refined_envoy_armor = set(ids.get("refined_envoy_armor").values())
+        ids_perfected_envoy_armor = set(ids.get("perfected_envoy_armor").values())
 
         # Filter empty slots and uninteresting items out of the inventories.
         #

--- a/cogs/guildwars2.py
+++ b/cogs/guildwars2.py
@@ -368,7 +368,7 @@ class GuildWars2:
         # `li_perfect_armor`.
         li_refined_armor = max(min(sum_perfect_armor, 6) + sum_refined_armor - 6, 0) * 25
         # Perfected Envoy Armor. First set is half off!
-        li_perfect_armor = 6 * 25 + max(sum_perfect_armor - 6, 0) * 50
+        li_perfect_armor = min(sum_perfect_armor, 6) * 25 + max(sum_perfect_armor - 6, 0) * 50
         # Stagger the calculation for detail later.
         crafted_li = li_prowess + li_insignia + li_perfect_armor + li_refined_armor
         total_li = sum_li + crafted_li
@@ -386,22 +386,22 @@ class GuildWars2:
         # Quick breakdown. No detail on WHERE all those LI are. That's for $search.
         embed.description = "{1} on hand, {2} used in crafting".format(total_li, sum_li, crafted_li)
         # Save space by skipping empty sections
-        if sum_perfect_armor > 0:
+        if li_perfect_armor > 25:
             embed.add_field(
                 name="{0} Perfected Envoy Armor Pieces".format(sum_perfect_armor),
                 value="Representing {0} Legendary Insights".format(li_perfect_armor),
                 inline=False)
-        if sum_refined_armor > 0:
+        if li_refined_armor > 25:
             embed.add_field(
                 name="{0} Refined Envoy Armor Pieces".format(sum_refined_armor),
                 value="Representing {0} Legendary Insights".format(li_refined_armor),
                 inline=False)
-        if sum_prowess > 0:
+        if li_prowess > 25:
             embed.add_field(
                 name="{0} Gifts of Prowess".format(sum_prowess),
                 value="Representing {0} Legendary Insights".format(li_prowess),
                 inline=False)
-        if sum_insignia > 0:
+        if li_insignia > 25:
             embed.add_field(
                 name="{0} Envoy Insignia".format(sum_insignia),
                 value="Representing {0} Legendary Insights".format(li_insignia),

--- a/cogs/guildwars2.py
+++ b/cogs/guildwars2.py
@@ -252,54 +252,57 @@ class GuildWars2:
         id_legendary_insight = 77302
         id_gift_of_prowess = 78989
         id_envoy_insignia = 80516
+        ids_refined_envoy_armor = {
+            # Helm, Shoulders, Coat,  Gloves, Leggings, Boots
+            80387,  80236,     80648, 80673,  80427,    80127, # Heavy
+            80634,  80366,     80607, 80658,  80675,    80177, # Medium
+            80441,  80264,     80120, 80460,  80275,    80583  # Light
+        }
         ids_perfected_envoy_armor = {
-            # Helm, Shoulders, Coat, Gloves, Leggings, Boots
-            80384, 80435, 80254, 80205, 80277, 80557, # heavy
-            80296, 80145, 80578, 80161, 80252, 80281, # medium
-            80248, 80131, 80190, 80111, 80356, 80399  # light
+            # Helm, Shoulders, Coat,  Gloves, Leggings, Boots
+            80384,  80435,     80254, 80205,  80277,    80557, # Heavy
+            80296,  80145,     80578, 80161,  80252,    80281, # Medium
+            80248,  80131,     80190, 80111,  80356,    80399  # Light
         }
 
-        # Filter empty slots out of the inventories to scan
+        # Filter empty slots and uninteresting items out of the inventories.
+        #
         # All inventories are converted to lists as they are used multiple
         # times. If they stay as generators, the first scan on each will exhaust
         # them, resulting in empty results for later scans (this was really hard
         # to track down, since the scans are also generators, so the order of
         # access to an inventory is not immediately obvious in the code).
-        # Since these lists may be large, also discard all completely
-        # uninteresting items right now.
-        __pre_filter = ids_perfected_envoy_armor.union({
-            id_legendary_insight, id_gift_of_prowess, id_envoy_insignia})
-        pre_filter = lambda a, b=__pre_filter: a["id"] in b
-        inv_bank = list(filter(pre_filter, filter(None, bank)))
+        __pre_filter = ids_perfected_envoy_armor.union(
+            {id_legendary_insight, id_gift_of_prowess, id_envoy_insignia},
+            ids_refined_envoy_armor)
+        # If an item slot is empty, or the item is not interesting, filter it out.
+        pre_filter = lambda a, b=__pre_filter: a is not None and a["id"] in b
+        inv_bank = list(filter(pre_filter, bank))
         del bank # We don't need these anymore, free them.
 
-        inv_shared = list(filter(pre_filter, filter(None, shared)))
+        inv_shared = list(filter(pre_filter, shared))
         del shared
 
         # Bags and equipment are a little more complicated
         # Bags have multiple inventories for each character, so:
-        # Step 6: Discard uninteresting
+        # Step 5: Discard the empty and uninteresting
         inv_bags = list(filter(pre_filter,
-            # Step 5: filter out empty slots
-            filter(None,
-                # Step 4: flatten!
+            # Step 4: Flatten!
+            chain.from_iterable(
+                # Step 3: Flatten.
                 chain.from_iterable(
-                    # Step 3: flatten.
-                    chain.from_iterable(
-                        # Step 2: get inventories from each existing bag
-                        (map(itemgetter("inventory"), filter(None, bags)) for bags in
-                            # Step 1: get all bags
-                            map(itemgetter("bags"), characters)))))))
+                    # Step 2: Get inventories from each existing bag
+                    (map(itemgetter("inventory"), filter(None, bags)) for bags in
+                        # Step 1: Get all bags
+                        map(itemgetter("bags"), characters))))))
         # Now we have a simple list of items in all bags on all characters.
 
-        # Step 4: Discard uninteresting
+        # Step 3: Discard empty and uninteresting
         equipped = list(filter(pre_filter,
-            # Step 3: flatten
+            # Step 2: Flatten
             chain.from_iterable(
-                # Step 2: Filter out empty slots
-                (filter(None, equipment) for equipment in
-                    # Step 1: get all character equipment
-                    map(itemgetter("equipment"), characters)))))
+                # Step 1: get all character equipment
+                map(itemgetter("equipment"), characters))))
         del characters
         # Like the bags, we now have a simple list of character gear
 
@@ -325,14 +328,21 @@ class GuildWars2:
 
         # This one is slightly different: since we are matching against a set
         # of ids, we use `in` instead of a simple comparison.
-        armor_scan = lambda a, b=ids_perfected_envoy_armor: a["id"] in b
-        armor_bank = map(itemgetter("count"), filter(armor_scan, inv_bank))
-        armor_shared = map(itemgetter("count"), filter(armor_scan, inv_shared))
-        armor_bags = map(itemgetter("count"), filter(armor_scan, inv_bags))
+        perfect_armor_scan = lambda a, b=ids_perfected_envoy_armor: a["id"] in b
+        perfect_armor_bank = map(itemgetter("count"), filter(perfect_armor_scan, inv_bank))
+        perfect_armor_shared = map(itemgetter("count"), filter(perfect_armor_scan, inv_shared))
+        perfect_armor_bags = map(itemgetter("count"), filter(perfect_armor_scan, inv_bags))
         # immediately converting this to a list because we'll need the length
         # later and that would exhaust the generator, resulting in surprises if
         # it's used more later.
-        armor_equipped = list(filter(armor_scan, equipped))
+        perfect_armor_equipped = list(filter(perfect_armor_scan, equipped))
+
+        # Repeat for Refined Armor
+        refined_armor_scan = lambda a, b=ids_refined_envoy_armor: a["id"] in b
+        refined_armor_bank = map(itemgetter("count"), filter(refined_armor_scan, inv_bank))
+        refined_armor_shared = map(itemgetter("count"), filter(refined_armor_scan, inv_shared))
+        refined_armor_bags = map(itemgetter("count"), filter(refined_armor_scan, inv_bags))
+        refined_armor_equipped = list(filter(refined_armor_scan, equipped))
 
         # Now that we have all the items we are interested in, it's time to
         # count them! Easy enough to just `sum` the `chain`.
@@ -342,15 +352,25 @@ class GuildWars2:
         # Armor is a little different. The ones in inventory have a count like
         # the other items, but the ones equipped don't, so we can just take the
         # length of the list there.
-        sum_armor = sum(chain(armor_bank, armor_shared, armor_bags)) + len(armor_equipped)
+        sum_refined_armor = sum(chain(refined_armor_bank, refined_armor_shared, refined_armor_bags)) + len(refined_armor_equipped)
+        sum_perfect_armor = sum(chain(perfect_armor_bank, perfect_armor_shared, perfect_armor_bags)) + len(perfect_armor_equipped)
 
         # LI is fine, but the others are composed of 25 or 50 LIs.
         li_prowess = sum_prowess * 25
         li_insignia = sum_insignia * 25
-        # First set is half off!
-        li_armor = li_armor = 6 * 25 + (sum_armor - 6) * 50 if sum_armor > 6 else sum_armor * 25
+        # Refined Envoy Armor. First set is free!
+        # But, keeping track of it is troublesome. What we do is add up to 6
+        # perfected armor pieces to this (the ones that used the free set), but
+        # not more (`min()`).
+        # Then, subtract 6 for the free set. If one full set of perfected armor
+        # has been crafted, then we have just the count of refined armor. This
+        # is exactly what we want, because the free set is now being counted by
+        # `li_perfect_armor`.
+        li_refined_armor = max(min(sum_perfect_armor, 6) + sum_refined_armor - 6, 0) * 25
+        # Perfected Envoy Armor. First set is half off!
+        li_perfect_armor = 6 * 25 + max(sum_perfect_armor - 6, 0) * 50
         # Stagger the calculation for detail later.
-        crafted_li = li_prowess + li_insignia + li_armor
+        crafted_li = li_prowess + li_insignia + li_perfect_armor + li_refined_armor
         total_li = sum_li + crafted_li
 
         # Construct an embed object for better formatting of our data
@@ -366,18 +386,26 @@ class GuildWars2:
         # Quick breakdown. No detail on WHERE all those LI are. That's for $search.
         embed.description = "{1} on hand, {2} used in crafting".format(total_li, sum_li, crafted_li)
         # Save space by skipping empty sections
-        if sum_armor > 0:
+        if sum_perfect_armor > 0:
             embed.add_field(
-                name="{0} Perfected Envoy Armor Pieces".format(sum_armor), inline=False,
-                value="Representing {0} Legendary Insights".format(li_armor))
+                name="{0} Perfected Envoy Armor Pieces".format(sum_perfect_armor),
+                value="Representing {0} Legendary Insights".format(li_perfect_armor),
+                inline=False)
+        if sum_refined_armor > 0:
+            embed.add_field(
+                name="{0} Refined Envoy Armor Pieces".format(sum_refined_armor),
+                value="Representing {0} Legendary Insights".format(li_refined_armor),
+                inline=False)
         if sum_prowess > 0:
             embed.add_field(
-                name="{0} Gifts of Prowess".format(sum_prowess), inline=False,
-                value="Representing {0} Legendary Insights".format(li_prowess))
+                name="{0} Gifts of Prowess".format(sum_prowess),
+                value="Representing {0} Legendary Insights".format(li_prowess),
+                inline=False)
         if sum_insignia > 0:
             embed.add_field(
-                name="{0} Envoy Insignia".format(sum_insignia), inline=False,
-                value="Representing {0} Legendary Insights".format(li_insignia))
+                name="{0} Envoy Insignia".format(sum_insignia),
+                value="Representing {0} Legendary Insights".format(li_insignia),
+                inline=False)
         # Identify the bot
         embed.set_footer(text=self.bot.user.name, icon_url=self.bot.user.avatar_url)
 

--- a/cogs/guildwars2.py
+++ b/cogs/guildwars2.py
@@ -326,9 +326,9 @@ class GuildWars2:
         # This one is slightly different: since we are matching against a set
         # of ids, we use `in` instead of a simple comparison.
         armor_scan = lambda a, b=ids_perfected_envoy_armor: a["id"] in b
-        armor_bank = filter(armor_scan, inv_bank)
-        armor_shared = filter(armor_scan, inv_shared)
-        armor_bags = filter(armor_scan, inv_bags)
+        armor_bank = map(itemgetter("count"), filter(armor_scan, inv_bank))
+        armor_shared = map(itemgetter("count"), filter(armor_scan, inv_shared))
+        armor_bags = map(itemgetter("count"), filter(armor_scan, inv_bags))
         # immediately converting this to a list because we'll need the length
         # later and that would exhaust the generator, resulting in surprises if
         # it's used more later.

--- a/data/guildwars2/gamedata.json
+++ b/data/guildwars2/gamedata.json
@@ -125,5 +125,50 @@
             { "name": "Crash Site",  "duration": 40, "color": "0xFCFADC" },
             { "name": "Sandstorm",  "duration": 20, "color": "0xDED98A" }]}
       ]
+    },
+    "insights": {
+      "legendary_insight":  77302,
+      "gift_of_prowess":    78989,
+      "envoy_insignia":     80516,
+      "refined_envoy_armor": {
+        "refined_envoy_helmet":       80387,
+        "refined_envoy_pauldrons":    80236,
+        "refined_envoy_breastplate":  80648,
+        "refined_envoy_gauntlets":    80673,
+        "refined_envoy_tassets":      80427,
+        "refined_envoy_greaves":      80127,
+        "refined_envoy_mask":         80634,
+        "refined_envoy_shoulderpads": 80366,
+        "refined_envoy_jerkin":       80607,
+        "refined_envoy_vambraces":    80658,
+        "refined_envoy_leggings":     80675,
+        "refined_envoy_boots":        80177,
+        "refined_envoy_cowl":         80441,
+        "refined_envoy_mantle":       80264,
+        "refined_envoy_vestments":    80120,
+        "refined_envoy_gloves":       80460,
+        "refined_envoy_pants":        80275,
+        "refined_envoy_shoes":        80583
+      },
+      "perfected_envoy_armor": {
+        "perfected_envoy_helmet":       80384,
+        "perfected_envoy_pauldrons":    80435,
+        "perfected_envoy_breastplate":  80254,
+        "perfected_envoy_gauntlets":    80205,
+        "perfected_envoy_tassets":      80277,
+        "perfected_envoy_greaves":      80557,
+        "perfected_envoy_mask":         80296,
+        "perfected_envoy_shoulderpads": 80145,
+        "perfected_envoy_jerkin":       80578,
+        "perfected_envoy_vambraces":    80161,
+        "perfected_envoy_leggings":     80252,
+        "perfected_envoy_boots":        80281,
+        "perfected_envoy_cowl":         80248,
+        "perfected_envoy_mantle":       80131,
+        "perfected_envoy_vestments":    80190,
+        "perfected_envoy_gloves":       80111,
+        "perfected_envoy_pants":        80356,
+        "perfected_envoy_shoes":        80399
+      }
    }
 }

--- a/data/guildwars2/gamedata.json
+++ b/data/guildwars2/gamedata.json
@@ -1,68 +1,68 @@
 {
     "professions" : {
-        "elementalist" : {
-            "color" : "0xDC423E",
-            "icon" : "https://wiki.guildwars2.com/images/a/a0/Elementalist_tango_icon_200px.png",
-            "name" : "Elementalist"
-        },
-        "engineer" : {
-            "color" : "0x87581D",
-            "icon" : "https://wiki.guildwars2.com/images/2/2f/Engineer_tango_icon_200px.png",
-            "name" : "Engineer"
-        },
-        "guardian" : {
-            "color" : "0x186885",
-            "icon" : "https://wiki.guildwars2.com/images/6/6c/Guardian_tango_icon_200px.png",
-            "name" : "Guardian"
-        },
-        "mesmer" : {
-            "color" : "0x69278A",
-            "icon" : "https://wiki.guildwars2.com/images/7/73/Mesmer_tango_icon_200px.png",
-            "name" : "Mesmer"
-        },
-        "necromancer" : {
-            "color" : "0x2C9D5D",
-            "icon" : "https://wiki.guildwars2.com/images/c/cd/Necromancer_tango_icon_200px.png",
-            "name" : "Necromancer"
-        },
-        "ranger" : {
-            "color" : "0x67A833",
-            "icon" : "https://wiki.guildwars2.com/images/5/51/Ranger_tango_icon_200px.png",
-            "name" : "Necromancer"
-        },
-        "revenant" : {
-            "color" : "0xA66356",
-            "icon" : "https://wiki.guildwars2.com/images/a/a8/Revenant_tango_icon_200px.png",
-            "name" : "Revenant"
-        },
-        "thief" : {
-            "color" : "0x974550",
-            "icon" : "https://wiki.guildwars2.com/images/1/19/Thief_tango_icon_200px.png",
-            "name" : "Thief"
-        },
-        "warrior" : {
-            "color" : "0xCAAA2A",
-            "icon" : "https://wiki.guildwars2.com/images/d/db/Warrior_tango_icon_200px.png",
-            "name" : "Warrior"
-        }
+      "elementalist" : {
+        "color" : "0xDC423E",
+        "icon" : "https://wiki.guildwars2.com/images/a/a0/Elementalist_tango_icon_200px.png",
+        "name" : "Elementalist"
+      },
+      "engineer" : {
+        "color" : "0x87581D",
+        "icon" : "https://wiki.guildwars2.com/images/2/2f/Engineer_tango_icon_200px.png",
+        "name" : "Engineer"
+      },
+      "guardian" : {
+        "color" : "0x186885",
+        "icon" : "https://wiki.guildwars2.com/images/6/6c/Guardian_tango_icon_200px.png",
+        "name" : "Guardian"
+      },
+      "mesmer" : {
+        "color" : "0x69278A",
+        "icon" : "https://wiki.guildwars2.com/images/7/73/Mesmer_tango_icon_200px.png",
+        "name" : "Mesmer"
+      },
+      "necromancer" : {
+        "color" : "0x2C9D5D",
+        "icon" : "https://wiki.guildwars2.com/images/c/cd/Necromancer_tango_icon_200px.png",
+        "name" : "Necromancer"
+      },
+      "ranger" : {
+        "color" : "0x67A833",
+        "icon" : "https://wiki.guildwars2.com/images/5/51/Ranger_tango_icon_200px.png",
+        "name" : "Necromancer"
+      },
+      "revenant" : {
+        "color" : "0xA66356",
+        "icon" : "https://wiki.guildwars2.com/images/a/a8/Revenant_tango_icon_200px.png",
+        "name" : "Revenant"
+      },
+      "thief" : {
+        "color" : "0x974550",
+        "icon" : "https://wiki.guildwars2.com/images/1/19/Thief_tango_icon_200px.png",
+        "name" : "Thief"
+      },
+      "warrior" : {
+        "color" : "0xCAAA2A",
+        "icon" : "https://wiki.guildwars2.com/images/d/db/Warrior_tango_icon_200px.png",
+        "name" : "Warrior"
+      }
     },
     "bosses" : {
-    "vale_guardian" : { "name" : "Vale Guardian", "order" : 0 },
-    "spirit_woods" : { "name" : "Spirit Woods", "order" : 1 },
-    "gorseval" : { "name" : "Gorseval the Multifarious", "order" : 2 },
-    "sabetha" : { "name" : "Sabetha the Saboteur", "order" : 3 },
-    "slothasor" :  { "name" : "Slothasor", "order" : 4 },
-    "bandit_trio" :  { "name" : "Bandit Trio", "order" : 5 },
-    "matthias" : { "name" : "Matthias Gabrel", "order" : 6 },
-    "escort" :  { "name" : "Siege the Stronghold", "order" : 7 },
-    "keep_construct" :  { "name" : "Keep Construct", "order" : 8 },
-    "twisted_castle" :  { "name" : "Twisted Castle", "order" : 9 },
-    "xera" : { "name" : "Xera", "order" : 10 },
-    "cairn" :  { "name" : "Cairn the Indomitable", "order" : 11 },
-    "mursaat_overseer" :  { "name" : "Mursaat Overseer", "order" : 12 },
-    "samarog" :  { "name" : "Samarog", "order" : 13 },
-    "deimos" :  { "name" : "Deimos", "order" : 14 }
-  },
+      "vale_guardian" : { "name" : "Vale Guardian", "order" : 0 },
+      "spirit_woods" : { "name" : "Spirit Woods", "order" : 1 },
+      "gorseval" : { "name" : "Gorseval the Multifarious", "order" : 2 },
+      "sabetha" : { "name" : "Sabetha the Saboteur", "order" : 3 },
+      "slothasor" :  { "name" : "Slothasor", "order" : 4 },
+      "bandit_trio" :  { "name" : "Bandit Trio", "order" : 5 },
+      "matthias" : { "name" : "Matthias Gabrel", "order" : 6 },
+      "escort" :  { "name" : "Siege the Stronghold", "order" : 7 },
+      "keep_construct" :  { "name" : "Keep Construct", "order" : 8 },
+      "twisted_castle" :  { "name" : "Twisted Castle", "order" : 9 },
+      "xera" : { "name" : "Xera", "order" : 10 },
+      "cairn" :  { "name" : "Cairn the Indomitable", "order" : 11 },
+      "mursaat_overseer" :  { "name" : "Mursaat Overseer", "order" : 12 },
+      "samarog" :  { "name" : "Samarog", "order" : 13 },
+      "deimos" :  { "name" : "Deimos", "order" : 14 }
+    },
     "pact_supply" : [
       "[&BA8CAAA=][&BKYBAAA=][&BEwDAAA=][&BIcHAAA=][&BNIEAAA=][&BIMCAAA=]",
       "[&BIMBAAA=][&BBkAAAA=][&BEgAAAA=][&BH8HAAA=][&BKgCAAA=][&BGQCAAA=]",
@@ -98,20 +98,20 @@
             { "name": "",  "duration": 10, "color": "0x84C147" },
             { "name": "Night Bosses",  "duration": 20, "color": "0x6DAC2F" },
             { "name": "Daytime", "duration": 75,  "color": "0xC4E2A5" },
-            { "name": "Night",  "duration": 15, "color": "0x84C147" }]}
+            { "name": "Night",  "duration": 15, "color": "0x84C147" }]},
         {"name": "Auric Basin",
          "phases": [
             { "name": "Pillars",  "duration": 45, "color": "0xFFE37F" },
             { "name": "Challenges",  "duration": 15, "color": "0xFFD53D" },
             { "name": "Octovine",  "duration": 20, "color": "0xEAB700" },
             { "name": "Reset",  "duration": 10, "color": "0xFFF1C1" },
-            { "name": "Pillars",  "duration": 30, "color": "0xFFE37F" }]}
+            { "name": "Pillars",  "duration": 30, "color": "0xFFE37F" }]},
         {"name": "Tangled Depths",
          "phases": [
             { "name": "",  "duration": 25, "color": "0xFFD7D7" },
             { "name": "Prep",  "duration": 5, "color": "0xffbdbd" },
             { "name": "Chak Gerent",  "duration": 20, "color": "0xf99" },
-            { "name": "Help the Outposts",  "duration": 70, "color": "0xFFD7D7" }]}
+            { "name": "Help the Outposts",  "duration": 70, "color": "0xFFD7D7" }]},
 
         {"name": "Dragon's Stand",
          "phases": [
@@ -125,5 +125,5 @@
             { "name": "Crash Site",  "duration": 40, "color": "0xFCFADC" },
             { "name": "Sandstorm",  "duration": 20, "color": "0xDED98A" }]}
       ]
-   },
+   }
 }


### PR DESCRIPTION
* Unequipped armor pieces no longer crash the command.
* Refined armor is no longer ignored. Crafted pieces will count in the LI tally. The free pieces are accounted for, even if they have been crafted into Perfect Envoy armor.
* Perfected armor tally no longer assumes the first set has been crafted (previously resulted in up to 150 extra LI, depending on the number of pieces crafted).
* Item ids moved into `gamedata.json`